### PR TITLE
Update to default-browser-id@1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "browser"
   ],
   "optionalDependencies": {
-    "default-browser-id": "1.0.4"
+    "default-browser-id": "^1.0.4"
   },
   "devDependencies": {
-    "jshint": "2.5.10",
-    "mocha": "2.0.1",
-    "rewire": "2.1.3"
+    "jshint": "^2.5.10",
+    "mocha": "^2.0.1",
+    "rewire": "^2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "browser"
   ],
   "optionalDependencies": {
-    "default-browser-id": "1.0.2"
+    "default-browser-id": "1.0.4"
   },
   "devDependencies": {
     "jshint": "2.5.10",


### PR DESCRIPTION
Upgrade to [get a fix](https://github.com/sindresorhus/default-browser-id/commit/58c6ee50dce34cbca3c45cd5231c6a596c2af283) that results in a consistent `node_modules` install regardless of install platform. This fixes an issue where you get different `npm shrinkwrap` output depending on what platform you're on.
