### PR TITLE
Change the ProgId for Microsoft Edge on Windows

### DIFF
--- a/lib/detect-windows10.js
+++ b/lib/detect-windows10.js
@@ -3,7 +3,7 @@ var exec = require('child_process').exec;
 module.exports = function (callback) {
 
     var registryQuery = 'HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\URLAssociations\\http\\UserChoice';
-    var command = 'reg query ' + registryQuery + ' | findstr "ProgId"';
+    var command = 'reg query ' + registryQuery + ' | findstr /i "ProgId"';
 
     exec(command, function (err, stdout, stderr) {
         var value;

--- a/lib/detect-windows10.js
+++ b/lib/detect-windows10.js
@@ -27,7 +27,7 @@ module.exports = function (callback) {
         }
 
         var out = {
-            isEdge:     value.indexOf('app') > -1,          // AppXq0fevzme2pys62n3e0fbqa7peapykr8v
+            isEdge:     value.indexOf('msedge') > -1,       // MSEdgeHTM
             isIE:       value.indexOf('ie.http') > -1,      // IE.HTTP
             isSafari:   value.indexOf('safari') > -1,       // SafariURL
             isFirefox:  value.indexOf('firefox') > -1,      // FirefoxURL

--- a/test/win10.js
+++ b/test/win10.js
@@ -84,7 +84,7 @@ describe("Windows 10 tests", function () {
     });
 
     it('detects edge', function (done) {
-        execResponse.stdout = '    ProgId    REG_SZ    AppXq0fevzme2pys62n3e0fbqa7peapykr8v\r\n';
+        execResponse.stdout = '    ProgId    REG_SZ    MSEdge.HTM\r\n';
 
         detect(function(err, res){
             assert.equal(res.isEdge, true);


### PR DESCRIPTION
The registry value of Microsoft Edge on my PC(Windows 10 21H1) is `MSEdge.HTM`.
The original code will return **unknown** when my default browser was set as Microsoft Edge.

It's my first pull request. Please inform me if there's any improvement.
Thanks!