### PR TITLE
Update to latest non esm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "browser"
   ],
   "optionalDependencies": {
-    "default-browser-id": "^1.0.4"
+    "default-browser-id": "^2.0.0"
   },
   "devDependencies": {
-    "jshint": "^2.5.10",
-    "mocha": "^2.0.1",
-    "rewire": "^2.1.3"
+    "jshint": "^2.13.5",
+    "mocha": "^10.0.0",
+    "rewire": "^6.0.0"
   }
 }


### PR DESCRIPTION
After adding macOS tests in #10, it should be possible to upgrade dependencies to the latest non-ESM dependencies.
This will, as mentioned in #8, close a handful security vulnerabilities.
Resolves #9 